### PR TITLE
Correct the confusing error message on format auto-detection failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -144,11 +145,14 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		var ok bool
 		if formatName == "auto" {
 			enc, ok = detectFormat(fileBytes, path)
+			if !ok {
+				return errors.New("failed to detect format of the input")
+			}
 		} else {
 			enc, ok = formats.ByName[strings.ToLower(formatName)]
-		}
-		if !ok {
-			return fmt.Errorf("no supported format found named %s", formatName)
+			if !ok {
+				return fmt.Errorf("no supported format found named %s", formatName)
+			}
 		}
 
 		jsonifiedFile, err := enc.MarshalJSONBytes(fileBytes)


### PR DESCRIPTION
Instead of saying `Error: no supported format found named auto` on feeding
unsupported input, faq now says:

```
$ jsonnet -y /dev/stdin <<< '[{x: 1, y: self.x} + {x: 10}, {z: 2}]' | ./faq
Error: failed to detect format of the input
```

Resolves #6