### PR TITLE
Support equivalent of jq's --slurp flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func runFaq(args []string, flags flags) error {
 	// verify all files exist, and open them:
 	var fileInfos []*fileInfo
 	for _, path := range paths {
-		fileInfo, err := readFile(path, flags)
+		fileInfo, err := openFile(path, flags)
 		if err != nil {
 			return err
 		}
@@ -271,7 +271,7 @@ func (info *fileInfo) GetContents() ([]byte, error) {
 	return info.data, nil
 }
 
-func readFile(path string, flags flags) (*fileInfo, error) {
+func openFile(path string, flags flags) (*fileInfo, error) {
 	path = os.ExpandEnv(path)
 	file, err := os.Open(path)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -185,7 +185,6 @@ func processFiles(outputWriter io.Writer, fileInfos []*fileInfo, program string,
 
 func combineJSONFiles(fileInfos []*fileInfo, inputFormat string) ([]byte, error) {
 	// we ignore the errors because byte.Buffers generally do not return
-	// we panic on the errors because byte.Buffers generally do not return
 	// error on write, and instead only panic when they cannot grow the
 	// underlying slice.
 	var buf bytes.Buffer

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -52,6 +53,7 @@ Supported formats:
 	rootCmd.Flags().BoolP("color-output", "c", true, "colorize the output")
 	rootCmd.Flags().BoolP("monochrome-output", "m", false, "monochrome (don't colorize the output)")
 	rootCmd.Flags().BoolP("pretty-output", "p", true, "pretty-printed output")
+	rootCmd.Flags().BoolP("slurp", "s", false, "read (slurp) all inputs into an array; apply filter to it")
 
 	rootCmd.Flags().MarkHidden("debug")
 
@@ -65,6 +67,7 @@ type flags struct {
 	color        bool
 	monochrome   bool
 	pretty       bool
+	slurp        bool
 }
 
 func runCmdFunc(cmd *cobra.Command, args []string) error {
@@ -75,14 +78,19 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	flags.color, _ = cmd.Flags().GetBool("color-output")
 	flags.pretty, _ = cmd.Flags().GetBool("pretty-output")
 	flags.monochrome, _ = cmd.Flags().GetBool("monochrome-output")
+	flags.slurp, _ = cmd.Flags().GetBool("slurp")
 	if runtime.GOOS == "windows" {
 		flags.monochrome = true
 	}
 
+	return runFaq(args, flags)
+}
+
+func runFaq(args []string, flags flags) error {
 	// Check to see execution is in an interactive terminal and set the args
 	// and flags as such.
 	program := ""
-	pathArgs := []string{}
+	paths := []string{}
 
 	// If stdout isn't an interactive tty, then default to monochrome.
 	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
@@ -94,13 +102,13 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		switch {
 		case len(args) == 0:
 			program = "."
-			pathArgs = []string{"/dev/stdin"}
+			paths = []string{"/dev/stdin"}
 		case len(args) == 1:
 			program = args[0]
-			pathArgs = []string{"/dev/stdin"}
+			paths = []string{"/dev/stdin"}
 		case len(args) > 1:
 			program = args[0]
-			pathArgs = args[1:]
+			paths = args[1:]
 		default:
 			return fmt.Errorf("not enough arguments provided")
 		}
@@ -109,12 +117,24 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("not enough arguments provided")
 		}
 		program = args[0]
-		pathArgs = args[1:]
+		paths = args[1:]
 	}
 
 	// Handle each file path provided.
-	for _, pathArg := range pathArgs {
-		err := processPathArg(pathArg, program, flags)
+	if flags.slurp {
+		if flags.outputFormat == "" {
+			return fmt.Errorf("must specify --output-format when using --slurp")
+		}
+		encoder, ok := formatByName(flags.outputFormat)
+		if !ok {
+			return fmt.Errorf("invalid --output-format %s", flags.outputFormat)
+		}
+		err := slurpFiles(paths, program, encoder, flags)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := processFiles(paths, program, flags)
 		if err != nil {
 			return err
 		}
@@ -123,40 +143,123 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func processPathArg(pathArg, program string, flags flags) error {
-	path := os.ExpandEnv(pathArg)
+// processFiles takes a list of files, and for each, attempts to convert it
+// to a JSON value and runs the jq program it
+func processFiles(paths []string, program string, flags flags) error {
+	for _, path := range paths {
+		fileInfo, err := readFile(path, flags)
+		if err != nil {
+			return err
+		}
+
+		err = runJQ(program, fileInfo.data, fileInfo.encoder, flags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// slurpFiles takes a list of files, and for each, attempts to convert it to
+// a JSON value and appends each JSON value  to an array, and passes that array
+// as the input to the jq program.
+func slurpFiles(paths []string, program string, encoder formats.Encoding, flags flags) error {
+	// we panic on the errors because byte.Buffers generally do not return
+	// error on write, and instead only panic when they cannot grow the
+	// underlying slice.
+	var buf bytes.Buffer
+
+	// append the first array bracket
+	_, err := buf.WriteRune('[')
+	if err != nil {
+		panic(err)
+	}
+
+	// iterate over each file, appending it's contents to an array
+	for i, path := range paths {
+		fileInfo, err := readFile(path, flags)
+		if err != nil {
+			return err
+		}
+		// only handle files with content
+		if len(bytes.TrimSpace(fileInfo.data)) != 0 {
+			_, err := buf.Write(fileInfo.data)
+			if err != nil {
+				panic(err)
+			}
+			// append the comma if it isn't the last item in the array
+			if i != len(paths)-1 {
+				_, err = buf.WriteRune(',')
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	}
+	// apend the last array bracket
+	_, err = buf.WriteRune(']')
+	if err != nil {
+		panic(err)
+	}
+
+	data := buf.Bytes()
+	if len(data) == 0 {
+		return nil
+	}
+
+	err = runJQ(program, data, encoder, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type fileInfo struct {
+	path             string
+	data             []byte
+	encoder, decoder formats.Encoding
+}
+
+func readFile(path string, flags flags) (*fileInfo, error) {
+	path = os.ExpandEnv(path)
 	fileBytes, err := ioutil.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("failed to read file at %s: `%s`", path, err)
+		return nil, fmt.Errorf("failed to read file at %s: `%s`", path, err)
 	}
 
 	// If there was no input, there's no output!
 	if len(fileBytes) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	decoder, err := determineDecoder(flags.inputFormat, path, fileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	encoder, err := determineEncoder(flags.outputFormat, decoder)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	jsonifiedFile, err := decoder.MarshalJSONBytes(fileBytes)
+	data, err := decoder.MarshalJSONBytes(fileBytes)
 	if err != nil {
-		return fmt.Errorf("failed to jsonify file at %s: `%s`", path, err)
+		return nil, fmt.Errorf("failed to jsonify file at %s: `%s`", path, err)
 	}
 
-	resultJvs, err := execJQProgram(program, path, jsonifiedFile)
+	return &fileInfo{path: path, data: data, encoder: encoder, decoder: decoder}, nil
+}
+
+func runJQ(program string, data []byte, encoder formats.Encoding, flags flags) error {
+	resultJvs, err := execJQProgram(program, data)
 	if err != nil {
 		return err
 	}
 
 	for _, resultJv := range resultJvs {
-		err := printJV(resultJv, encoder, decoder, flags)
+		err := printJV(resultJv, encoder, flags)
 		if err != nil {
 			return err
 		}
@@ -165,7 +268,7 @@ func processPathArg(pathArg, program string, flags flags) error {
 	return nil
 }
 
-func printJV(jv *jq.Jv, encoder, decoder formats.Encoding, flags flags) error {
+func printJV(jv *jq.Jv, encoder formats.Encoding, flags flags) error {
 	resultBytes := []byte(jv.Dump(jq.JvPrintNone))
 	output, err := encoder.UnmarshalJSONBytes(resultBytes)
 	if err != nil {
@@ -195,7 +298,7 @@ func printJV(jv *jq.Jv, encoder, decoder formats.Encoding, flags flags) error {
 	return nil
 }
 
-func execJQProgram(program, path string, jsonBytes []byte) ([]*jq.Jv, error) {
+func execJQProgram(program string, jsonBytes []byte) ([]*jq.Jv, error) {
 	libjq, err := jq.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize libjq: %s", err)
@@ -204,19 +307,20 @@ func execJQProgram(program, path string, jsonBytes []byte) ([]*jq.Jv, error) {
 
 	fileJv, err := jq.JvFromJSONBytes(jsonBytes)
 	if err != nil {
-		panic("failed to convert jsonified file into jv")
+		return nil, fmt.Errorf("unable to convert to json value from bytes: %s", err)
 	}
 
 	errs := libjq.Compile(program, jq.JvArray())
+	// errs := libjq.Compile(program, jq.JvArray())
 	for _, err := range errs {
 		if err != nil {
-			return nil, fmt.Errorf("failed to compile jq program for file at %s: %s", path, err)
+			return nil, fmt.Errorf("failed to compile jq program: %s", err)
 		}
 	}
 
 	resultJvs, err := libjq.Execute(fileJv)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute jq program for file at %s: %s", path, err)
+		return nil, fmt.Errorf("failed to execute jq program: %s", err)
 	}
 
 	return resultJvs, nil
@@ -231,7 +335,7 @@ func determineDecoder(inputFormat, path string, fileBytes []byte) (formats.Encod
 			return nil, errors.New("failed to detect format of the input")
 		}
 	} else {
-		decoder, ok = formats.ByName[strings.ToLower(inputFormat)]
+		decoder, ok = formatByName(inputFormat)
 		if !ok {
 			return nil, fmt.Errorf("no supported format found named %s", inputFormat)
 		}
@@ -246,7 +350,7 @@ func determineEncoder(outputFormat string, decoder formats.Encoding) (formats.En
 	if outputFormat == "auto" {
 		encoder = decoder
 	} else {
-		encoder, ok = formats.ByName[strings.ToLower(outputFormat)]
+		encoder, ok = formatByName(outputFormat)
 		if !ok {
 			return nil, fmt.Errorf("no supported format found named %s", outputFormat)
 		}
@@ -257,7 +361,7 @@ func determineEncoder(outputFormat string, decoder formats.Encoding) (formats.En
 
 func detectFormat(fileBytes []byte, path string) (formats.Encoding, bool) {
 	if ext := filepath.Ext(path); ext != "" {
-		if format, ok := formats.ByName[ext[1:]]; ok {
+		if format, ok := formatByName(ext[1:]); ok {
 			return format, true
 		}
 	}
@@ -274,4 +378,11 @@ func detectFormat(fileBytes []byte, path string) (formats.Encoding, bool) {
 	// Go isn't smart enough to do this in one line.
 	enc, ok := formats.ByName[format]
 	return enc, ok
+}
+
+func formatByName(name string) (formats.Encoding, bool) {
+	if format, ok := formats.ByName[strings.ToLower(name)]; ok {
+		return format, true
+	}
+	return nil, false
 }

--- a/main.go
+++ b/main.go
@@ -162,19 +162,16 @@ func processFiles(paths []string, program string, flags flags) error {
 }
 
 // slurpFiles takes a list of files, and for each, attempts to convert it to
-// a JSON value and appends each JSON value  to an array, and passes that array
+// a JSON value and appends each JSON value to an array, and passes that array
 // as the input to the jq program.
 func slurpFiles(paths []string, program string, encoder formats.Encoding, flags flags) error {
-	// we panic on the errors because byte.Buffers generally do not return
+	// we ignore the errors because byte.Buffers generally do not return
 	// error on write, and instead only panic when they cannot grow the
 	// underlying slice.
 	var buf bytes.Buffer
 
 	// append the first array bracket
-	_, err := buf.WriteRune('[')
-	if err != nil {
-		panic(err)
-	}
+	buf.WriteRune('[')
 
 	// iterate over each file, appending it's contents to an array
 	for i, path := range paths {
@@ -184,31 +181,22 @@ func slurpFiles(paths []string, program string, encoder formats.Encoding, flags 
 		}
 		// only handle files with content
 		if len(bytes.TrimSpace(fileInfo.data)) != 0 {
-			_, err := buf.Write(fileInfo.data)
-			if err != nil {
-				panic(err)
-			}
+			buf.Write(fileInfo.data)
 			// append the comma if it isn't the last item in the array
 			if i != len(paths)-1 {
-				_, err = buf.WriteRune(',')
-				if err != nil {
-					panic(err)
-				}
+				buf.WriteRune(',')
 			}
 		}
 	}
 	// apend the last array bracket
-	_, err = buf.WriteRune(']')
-	if err != nil {
-		panic(err)
-	}
+	buf.WriteRune(']')
 
 	data := buf.Bytes()
 	if len(data) == 0 {
 		return nil
 	}
 
-	err = runJQ(program, data, encoder, flags)
+	err := runJQ(program, data, encoder, flags)
 	if err != nil {
 		return err
 	}
@@ -311,7 +299,6 @@ func execJQProgram(program string, jsonBytes []byte) ([]*jq.Jv, error) {
 	}
 
 	errs := libjq.Compile(program, jq.JvArray())
-	// errs := libjq.Compile(program, jq.JvArray())
 	for _, err := range errs {
 		if err != nil {
 			return nil, fmt.Errorf("failed to compile jq program: %s", err)

--- a/main.go
+++ b/main.go
@@ -257,18 +257,15 @@ func (info *fileInfo) MarshalJSONBytes(decoder formats.Encoding) ([]byte, error)
 
 func (info *fileInfo) GetContents() ([]byte, error) {
 	if !info.read {
+		if readCloser, ok := info.reader.(io.ReadCloser); ok {
+			defer readCloser.Close()
+		}
 		var err error
 		info.data, err = ioutil.ReadAll(info.reader)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file at %s: `%s`", info.path, err)
 		}
 
-		if readCloser, ok := info.reader.(io.ReadCloser); ok {
-			err = readCloser.Close()
-			if err != nil {
-				return nil, fmt.Errorf("failed to close file at %s: `%s`", info.path, err)
-			}
-		}
 		info.read = true
 	}
 	return info.data, nil

--- a/main.go
+++ b/main.go
@@ -188,14 +188,10 @@ func slurpFiles(paths []string, program string, encoder formats.Encoding, flags 
 			}
 		}
 	}
-	// apend the last array bracket
+	// append the last array bracket
 	buf.WriteRune(']')
 
 	data := buf.Bytes()
-	if len(data) == 0 {
-		return nil
-	}
-
 	err := runJQ(program, data, encoder, flags)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -120,6 +121,16 @@ func runFaq(args []string, flags flags) error {
 		paths = args[1:]
 	}
 
+	// verify all files exist, and open them:
+	var fileInfos []*fileInfo
+	for _, path := range paths {
+		fileInfo, err := readFile(path, flags)
+		if err != nil {
+			return err
+		}
+		fileInfos = append(fileInfos, fileInfo)
+	}
+
 	// Handle each file path provided.
 	if flags.slurp {
 		if flags.outputFormat == "" {
@@ -129,12 +140,12 @@ func runFaq(args []string, flags flags) error {
 		if !ok {
 			return fmt.Errorf("invalid --output-format %s", flags.outputFormat)
 		}
-		err := slurpFiles(paths, program, encoder, flags)
+		err := slurpFiles(fileInfos, program, encoder, flags)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := processFiles(paths, program, flags)
+		err := processFiles(fileInfos, program, flags)
 		if err != nil {
 			return err
 		}
@@ -145,14 +156,21 @@ func runFaq(args []string, flags flags) error {
 
 // processFiles takes a list of files, and for each, attempts to convert it
 // to a JSON value and runs the jq program it
-func processFiles(paths []string, program string, flags flags) error {
-	for _, path := range paths {
-		fileInfo, err := readFile(path, flags)
+func processFiles(fileInfos []*fileInfo, program string, flags flags) error {
+	for _, fileInfo := range fileInfos {
+		decoder, err := determineDecoder(flags.inputFormat, fileInfo)
 		if err != nil {
 			return err
 		}
-
-		err = runJQ(program, fileInfo.data, fileInfo.encoder, flags)
+		data, err := fileInfo.MarshalJSONBytes(decoder)
+		if err != nil {
+			return err
+		}
+		encoder, err := determineEncoder(flags.outputFormat, decoder)
+		if err != nil {
+			return err
+		}
+		err = runJQ(program, data, encoder, flags)
 		if err != nil {
 			return err
 		}
@@ -164,8 +182,9 @@ func processFiles(paths []string, program string, flags flags) error {
 // slurpFiles takes a list of files, and for each, attempts to convert it to
 // a JSON value and appends each JSON value to an array, and passes that array
 // as the input to the jq program.
-func slurpFiles(paths []string, program string, encoder formats.Encoding, flags flags) error {
+func slurpFiles(fileInfos []*fileInfo, program string, encoder formats.Encoding, flags flags) error {
 	// we ignore the errors because byte.Buffers generally do not return
+	// we panic on the errors because byte.Buffers generally do not return
 	// error on write, and instead only panic when they cannot grow the
 	// underlying slice.
 	var buf bytes.Buffer
@@ -174,16 +193,22 @@ func slurpFiles(paths []string, program string, encoder formats.Encoding, flags 
 	buf.WriteRune('[')
 
 	// iterate over each file, appending it's contents to an array
-	for i, path := range paths {
-		fileInfo, err := readFile(path, flags)
+	for i, fileInfo := range fileInfos {
+		// only handle files with content
+
+		decoder, err := determineDecoder(flags.inputFormat, fileInfo)
 		if err != nil {
 			return err
 		}
-		// only handle files with content
-		if len(bytes.TrimSpace(fileInfo.data)) != 0 {
-			buf.Write(fileInfo.data)
+
+		data, err := fileInfo.MarshalJSONBytes(decoder)
+		if err != nil {
+			return err
+		}
+		if len(bytes.TrimSpace(data)) != 0 {
+			buf.Write(data)
 			// append the comma if it isn't the last item in the array
-			if i != len(paths)-1 {
+			if i != len(fileInfos)-1 {
 				buf.WriteRune(',')
 			}
 		}
@@ -201,39 +226,51 @@ func slurpFiles(paths []string, program string, encoder formats.Encoding, flags 
 }
 
 type fileInfo struct {
-	path             string
-	data             []byte
-	encoder, decoder formats.Encoding
+	path   string
+	reader io.Reader
+	data   []byte
+	read   bool
+}
+
+func (info *fileInfo) MarshalJSONBytes(decoder formats.Encoding) ([]byte, error) {
+	fileBytes, err := info.GetContents()
+	if err != nil {
+		return nil, err
+	}
+	data, err := decoder.MarshalJSONBytes(fileBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to jsonify file at %s: `%s`", info.path, err)
+	}
+	return data, err
+}
+
+func (info *fileInfo) GetContents() ([]byte, error) {
+	if !info.read {
+		var err error
+		info.data, err = ioutil.ReadAll(info.reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file at %s: `%s`", info.path, err)
+		}
+
+		if readCloser, ok := info.reader.(io.ReadCloser); ok {
+			err = readCloser.Close()
+			if err != nil {
+				return nil, fmt.Errorf("failed to close file at %s: `%s`", info.path, err)
+			}
+		}
+		info.read = true
+	}
+	return info.data, nil
 }
 
 func readFile(path string, flags flags) (*fileInfo, error) {
 	path = os.ExpandEnv(path)
-	fileBytes, err := ioutil.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file at %s: `%s`", path, err)
 	}
 
-	// If there was no input, there's no output!
-	if len(fileBytes) == 0 {
-		return nil, nil
-	}
-
-	decoder, err := determineDecoder(flags.inputFormat, path, fileBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	encoder, err := determineEncoder(flags.outputFormat, decoder)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := decoder.MarshalJSONBytes(fileBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to jsonify file at %s: `%s`", path, err)
-	}
-
-	return &fileInfo{path: path, data: data, encoder: encoder, decoder: decoder}, nil
+	return &fileInfo{path: path, reader: file}, nil
 }
 
 func runJQ(program string, data []byte, encoder formats.Encoding, flags flags) error {
@@ -309,19 +346,20 @@ func execJQProgram(program string, jsonBytes []byte) ([]*jq.Jv, error) {
 	return resultJvs, nil
 }
 
-func determineDecoder(inputFormat, path string, fileBytes []byte) (formats.Encoding, error) {
+func determineDecoder(inputFormat string, fileInfo *fileInfo) (formats.Encoding, error) {
 	var decoder formats.Encoding
-	var ok bool
+	var err error
 	if inputFormat == "auto" {
-		decoder, ok = detectFormat(fileBytes, path)
-		if !ok {
-			return nil, errors.New("failed to detect format of the input")
-		}
+		decoder, err = detectFormat(fileInfo)
 	} else {
+		var ok bool
 		decoder, ok = formatByName(inputFormat)
 		if !ok {
-			return nil, fmt.Errorf("no supported format found named %s", inputFormat)
+			err = fmt.Errorf("no supported format found named %s", inputFormat)
 		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return decoder, nil
@@ -342,14 +380,18 @@ func determineEncoder(outputFormat string, decoder formats.Encoding) (formats.En
 	return encoder, nil
 }
 
-func detectFormat(fileBytes []byte, path string) (formats.Encoding, bool) {
-	if ext := filepath.Ext(path); ext != "" {
+func detectFormat(fileInfo *fileInfo) (formats.Encoding, error) {
+	if ext := filepath.Ext(fileInfo.path); ext != "" {
 		if format, ok := formatByName(ext[1:]); ok {
-			return format, true
+			return format, nil
 		}
 	}
 
-	format := linguist.LanguageByContents(fileBytes, linguist.LanguageHints(path))
+	fileBytes, err := fileInfo.GetContents()
+	if err != nil {
+		return nil, err
+	}
+	format := linguist.LanguageByContents(fileBytes, linguist.LanguageHints(fileInfo.path))
 	format = strings.ToLower(format)
 
 	// This is what linguist says when it has no idea what it's talking about.
@@ -360,7 +402,10 @@ func detectFormat(fileBytes []byte, path string) (formats.Encoding, bool) {
 
 	// Go isn't smart enough to do this in one line.
 	enc, ok := formats.ByName[format]
-	return enc, ok
+	if !ok {
+		return nil, errors.New("failed to detect format of the input")
+	}
+	return enc, nil
 }
 
 func formatByName(name string) (formats.Encoding, bool) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRunFaq(t *testing.T) {
+	testCases := []struct {
+		name              string
+		program           string
+		inputFileContents []string
+		flags             flags
+		expectedOutput    string
+	}{
+		{
+			name:              "empty file simple program",
+			program:           ".",
+			inputFileContents: []string{},
+		},
+		{
+			name:    "single file empty object simple program",
+			program: ".",
+			inputFileContents: []string{
+				`{}`,
+			},
+			expectedOutput: "{}\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+			},
+		},
+		{
+			name:    "single file empty string simple program",
+			program: ".",
+			inputFileContents: []string{
+				`""`,
+			},
+			expectedOutput: `""` + "\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+			},
+		},
+		{
+			name:    "single file bool simple program",
+			program: ".",
+			inputFileContents: []string{
+				`true`,
+			},
+			expectedOutput: "true\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+			},
+		},
+		{
+			name:    "multiple file simple program",
+			program: ".",
+			inputFileContents: []string{
+				`{}`,
+				`true`,
+			},
+			expectedOutput: "{}\ntrue\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+			},
+		},
+		{
+			name:    "slurp single file empty",
+			program: ".",
+			inputFileContents: []string{
+				``,
+			},
+			expectedOutput: "[]\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+				slurp:        true,
+			},
+		},
+		{
+			name:    "slurp multiple file empty",
+			program: ".",
+			inputFileContents: []string{
+				``,
+				``,
+			},
+			expectedOutput: "[]\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+				slurp:        true,
+			},
+		},
+		{
+			name:    "slurp multiple file simple",
+			program: ".",
+			inputFileContents: []string{
+				`{}`,
+				``,   // empty files are ignored
+				`""`, // an empty string is valid
+				`true`,
+			},
+			expectedOutput: `[{},"",true]` + "\n",
+			flags: flags{
+				inputFormat:  "json",
+				outputFormat: "json",
+				slurp:        true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			var fileInfos []*fileInfo
+			for i, fileContent := range testCase.inputFileContents {
+				fileInfos = append(fileInfos, &fileInfo{
+					path: "test-path-" + string(i),
+					read: true,
+					data: []byte(fileContent),
+				})
+			}
+			var outputBuf bytes.Buffer
+			err := runFaq2(&outputBuf, fileInfos, testCase.program, testCase.flags)
+			if err != nil {
+				t.Errorf("expected no err, got %#v", err)
+			}
+			output := outputBuf.String()
+			if output != testCase.expectedOutput {
+				t.Errorf("incorrect output expected=%s, got=%s", testCase.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -124,7 +124,7 @@ func TestRunFaq(t *testing.T) {
 				})
 			}
 			var outputBuf bytes.Buffer
-			err := runFaq2(&outputBuf, fileInfos, testCase.program, testCase.flags)
+			err := runFaq(&outputBuf, fileInfos, testCase.program, testCase.flags)
 			if err != nil {
 				t.Errorf("expected no err, got %#v", err)
 			}


### PR DESCRIPTION
Enables easily accepting multiple files by slurping all files provided
as arguments and passing them as an array of JSON values to the jq
program.

Ex:

jq:
```
jq -s '.' <(echo '{}') <(echo ' ') <(echo 'true')
[
  {},
  true
]
```

faq:
```
./faq -o json -f json -s '.' <(echo '{}') <(echo ' ') <(echo 'true')
[
  {},
  true
]
```