### PR TITLE
WIP: Support yaml document streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,7 @@ require (
 	golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee
+	k8s.io/klog v0.1.0 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,3 +76,9 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee h1:3MH/wGFP+9PjyLIMnPN2GYatdJosd+5TnSO2BzQqqo4=
+k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=
+k8s.io/klog v0.1.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
+sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/jzelinskie/faq/formats"
 	"github.com/jzelinskie/faq/jq"
@@ -159,27 +161,65 @@ func runFaq(outputWriter io.Writer, fileInfos []*fileInfo, program string, flags
 }
 
 // processFiles takes a list of files, and for each, attempts to convert it
-// to a JSON value and runs the jq program it
+// to a JSON value and runs the jq program against it
 func processFiles(outputWriter io.Writer, fileInfos []*fileInfo, program string, flags flags) error {
 	for _, fileInfo := range fileInfos {
 		decoder, err := determineDecoder(flags.inputFormat, fileInfo)
 		if err != nil {
 			return err
 		}
-		data, err := fileInfo.MarshalJSONBytes(decoder)
+
+		fileBytes, err := fileInfo.GetContents()
 		if err != nil {
 			return err
 		}
-		encoder, err := determineEncoder(flags.outputFormat, decoder)
-		if err != nil {
-			return err
-		}
-		err = runJQ(outputWriter, program, data, encoder, flags)
-		if err != nil {
-			return err
+
+		if flags.inputFormat == "yaml" {
+			// handle yaml streams
+			docDecoder := yaml.NewYAMLReader(bufio.NewReader(bytes.NewBuffer(fileBytes)))
+			for {
+				var docBytes []byte
+				docBytes, err := docDecoder.Read()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return err
+				}
+				if len(bytes.TrimSpace(docBytes)) != 0 {
+					err = convertInputAndRun(outputWriter, decoder, docBytes, fileInfo.path, program, flags)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			if len(bytes.TrimSpace(fileBytes)) != 0 {
+				err := convertInputAndRun(outputWriter, decoder, fileBytes, fileInfo.path, program, flags)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 
+	return nil
+}
+
+func convertInputAndRun(outputWriter io.Writer, decoder formats.Encoding, fileBytes []byte, path, program string, flags flags) error {
+	data, err := decoder.MarshalJSONBytes(fileBytes)
+	if err != nil {
+		return fmt.Errorf("failed to jsonify file at %s: `%s`", path, err)
+	}
+
+	encoder, err := determineEncoder(flags.outputFormat, decoder)
+	if err != nil {
+		return err
+	}
+	err = runJQ(outputWriter, program, data, encoder, flags)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -196,17 +236,64 @@ func combineJSONFilesToJSONArray(fileInfos []*fileInfo, inputFormat string) ([]b
 			return nil, err
 		}
 
-		data, err := fileInfo.MarshalJSONBytes(decoder)
+		fileBytes, err := fileInfo.GetContents()
 		if err != nil {
 			return nil, err
 		}
-		if len(bytes.TrimSpace(data)) != 0 {
-			buf.Write(data)
-			// append the comma if it isn't the last item in the array
-			if i != len(fileInfos)-1 {
-				buf.WriteRune(',')
+
+		if inputFormat == "yaml" {
+			// check if the file is a yaml stream containing multiple documents
+			docDecoder := yaml.NewYAMLReader(bufio.NewReader(bytes.NewBuffer(fileBytes)))
+
+			var items [][]byte
+			for {
+				docBytes, err := docDecoder.Read()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return nil, err
+				}
+				docAsJSON, err := decoder.MarshalJSONBytes(docBytes)
+				if err != nil {
+					return nil, fmt.Errorf("failed to jsonify file at %s: `%s`", fileInfo.path, err)
+				}
+
+				if len(bytes.TrimSpace(docAsJSON)) != 0 {
+					items = append(items, docAsJSON)
+				}
+			}
+
+			if len(items) != 0 {
+				for j, data := range items {
+					// write each document
+					buf.Write(data)
+					// write a comma between each document unless it's the last
+					// document
+					if j != len(items)-1 {
+						buf.WriteRune(',')
+					}
+				}
+				// write a comma between the contents of each file unless we're
+				// on the last file
+				if i != len(fileInfos)-1 {
+					buf.WriteRune(',')
+				}
+			}
+		} else {
+			data, err := decoder.MarshalJSONBytes(fileBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to jsonify file at %s: `%s`", fileInfo.path, err)
+			}
+
+			if len(bytes.TrimSpace(data)) != 0 {
+				buf.Write(data)
+				if i != len(fileInfos)-1 {
+					buf.WriteRune(',')
+				}
 			}
 		}
+
 	}
 	// append the last array bracket
 	buf.WriteRune(']')
@@ -236,18 +323,6 @@ type fileInfo struct {
 	reader io.Reader
 	data   []byte
 	read   bool
-}
-
-func (info *fileInfo) MarshalJSONBytes(decoder formats.Encoding) ([]byte, error) {
-	fileBytes, err := info.GetContents()
-	if err != nil {
-		return nil, err
-	}
-	data, err := decoder.MarshalJSONBytes(fileBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to jsonify file at %s: `%s`", info.path, err)
-	}
-	return data, err
 }
 
 func (info *fileInfo) GetContents() ([]byte, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -43,6 +43,81 @@ func TestRunFaq(t *testing.T) {
 			},
 		},
 		{
+			name:    "single file yaml stream simple program",
+			program: ".",
+			inputFileContents: []string{
+				`---
+foo: true
+---
+bar: false`,
+			},
+			expectedOutput: `{"foo":true}
+{"bar":false}
+`,
+			flags: flags{
+				inputFormat:  "yaml",
+				outputFormat: "json",
+			},
+		},
+		{
+			// TODO: this should return "" as the output probably
+			name:    "FIXME single file yaml single empty yaml stream simple program",
+			program: ".",
+			inputFileContents: []string{
+				`---
+`,
+			},
+			expectedOutput: `null
+`,
+			flags: flags{
+				inputFormat:  "yaml",
+				outputFormat: "json",
+			},
+		},
+		{
+			// TODO: this should return "" as the output probably
+			name:    "FIXME single file yaml multiple empty yaml stream simple program",
+			program: ".",
+			inputFileContents: []string{
+				`---
+---
+---
+`,
+			},
+			expectedOutput: "null\nnull\n",
+			flags: flags{
+				inputFormat:  "yaml",
+				outputFormat: "json",
+			},
+		},
+		{
+			name:    "single file yaml stream with extra newlines simple program",
+			program: ".",
+			inputFileContents: []string{
+				// these extra newlines are intentionally here to ensure
+				// they're not treated specially
+				`
+
+
+---
+
+foo: true
+
+---
+
+bar: false
+
+`,
+			},
+			expectedOutput: `{"foo":true}
+{"bar":false}
+`,
+			flags: flags{
+				inputFormat:  "yaml",
+				outputFormat: "json",
+			},
+		},
+		{
 			name:    "single file bool simple program",
 			program: ".",
 			inputFileContents: []string{
@@ -110,6 +185,28 @@ func TestRunFaq(t *testing.T) {
 				slurp:        true,
 			},
 		},
+		{
+			name:    "slurp multiple file yaml stream simple program",
+			program: ".",
+			inputFileContents: []string{
+				`---
+foo: true
+---
+bar: false`,
+				`---
+fizz: buzz
+---
+cats: dogs
+`,
+			},
+			expectedOutput: `[{"foo":true},{"bar":false},{"fizz":"buzz"},{"cats":"dogs"}]
+`,
+			flags: flags{
+				inputFormat:  "yaml",
+				outputFormat: "json",
+				slurp:        true,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -128,6 +225,7 @@ func TestRunFaq(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected no err, got %#v", err)
 			}
+
 			output := outputBuf.String()
 			if output != testCase.expectedOutput {
 				t.Errorf("incorrect output expected=%s, got=%s", testCase.expectedOutput, output)


### PR DESCRIPTION
Support multiple yaml documents in a single file/stream separated by `---`

WIP because I'm not 100% happy with the behavior with empty yaml streams but it
does work overall and has decent tests.