### PR TITLE
WIP Support passing additional args/variables to jq program

### DIFF
--- a/formats/yaml_helpers.go
+++ b/formats/yaml_helpers.go
@@ -1,6 +1,7 @@
 // this file contains code from https://github.com/ghodss/yaml/tree/c7ce16629ff4cd059ed96ed06419dd3856fd3577
 // it contains convertToJSONableObject from yaml.go and all of fields.go
 
+// Package formats contains code for dealing with formats isomorphic with JSON.
 // Copyright 2013 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -682,6 +683,4 @@ func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (in
 		}
 		return yamlObj, nil
 	}
-
-	return nil, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,14 @@ require (
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.0.5
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.1 // indirect
+	github.com/spf13/pflag v1.0.1
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/zeebo/bencode v0.0.0-20180308174530-d522839ac797
 	golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/yaml.v2 v2.2.1
-	k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee
+	k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee // indirect
 	k8s.io/klog v0.1.0 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -175,19 +175,19 @@ func (jq *Jq) Start(program string, args *Jv) (in chan<- *Jv, out <-chan *Jv, er
 
 	// Before setting up any of the global error handling state, lets check that
 	// args is of the right type!
-	if args.Kind() != JvKindArray {
-		go func() {
-			// Take ownership of the inputs
-			for jv := range cIn {
-				jv.Free()
-			}
-			cErr <- fmt.Errorf("`args` parameter is of type %s not array", args.Kind().String())
-			args.Free()
-			close(cOut)
-			close(cErr)
-		}()
-		return
-	}
+	// if args.Kind() != JvKindArray {
+	// 	go func() {
+	// 		// Take ownership of the inputs
+	// 		for jv := range cIn {
+	// 			jv.Free()
+	// 		}
+	// 		cErr <- fmt.Errorf("`args` parameter is of type %s not array", args.Kind().String())
+	// 		args.Free()
+	// 		close(cOut)
+	// 		close(cErr)
+	// 	}()
+	// 	return
+	// }
 
 	if jq.errorStoreID != 0 {
 		// We might have called Compile
@@ -272,10 +272,10 @@ func (jq *Jq) Compile(prog string, args *Jv) (errs []error) {
 
 	// Before setting up any of the global error handling state, lets check that
 	// args is of the right type!
-	if args.Kind() != JvKindArray {
-		args.Free()
-		return []error{fmt.Errorf("`args` parameter is of type %s not array", args.Kind().String())}
-	}
+	// if args.Kind() != JvKindArray {
+	// 	args.Free()
+	// 	return []error{fmt.Errorf("`args` parameter is of type %s not array", args.Kind().String())}
+	// }
 
 	cErr := make(chan error)
 

--- a/pkg/flagutil/flags.go
+++ b/pkg/flagutil/flags.go
@@ -1,0 +1,118 @@
+package flagutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	// validate these types implement the pflag.Value interface at compile time
+	_ pflag.Value = &KwargStringFlag{}
+	_ pflag.Value = &PositionalArgStringFlag{}
+)
+
+// KwargStringFlag implements pflag.Value that accepts key=value pairs and can be
+// passed multiple times to support multiple pairs.
+type KwargStringFlag struct {
+	value   *map[string][]byte
+	changed bool
+}
+
+// NewKwargStringFlag returns an initialized KwargStringFlag
+func NewKwargStringFlag() *KwargStringFlag {
+	return &KwargStringFlag{
+		value: new(map[string][]byte),
+	}
+}
+
+// AsMap returns a map of key value pairs passed via the flag
+func (f *KwargStringFlag) AsMap() map[string][]byte {
+	if f.value != nil {
+		return *f.value
+	}
+	return nil
+}
+
+// String implements pflag.Value
+func (f *KwargStringFlag) String() string {
+	return fmt.Sprintf("%v", f.AsMap())
+}
+
+// Set implements pflag.Value
+func (f *KwargStringFlag) Set(input string) error {
+	p, err := parseKeyValuePair(input)
+	if err != nil {
+		return err
+	}
+	if !f.changed {
+		// first time set is called so assign to *f.value
+		*f.value = map[string][]byte{p.Key: p.Value}
+	} else {
+		// after first time just update existing *f.value
+		(*f.value)[p.Key] = p.Value
+	}
+	f.changed = true
+	return nil
+}
+
+// Type implements pflag.Value
+func (f *KwargStringFlag) Type() string {
+	return "key=value"
+}
+
+type pair struct {
+	Key   string
+	Value []byte
+}
+
+func parseKeyValuePair(input string) (*pair, error) {
+	if input == "" {
+		return nil, nil
+	}
+	pairSplit := strings.SplitN(input, "=", 2)
+	if len(pairSplit) == 1 {
+		return nil, fmt.Errorf("did not find any key=value pairs in %s)", input)
+	}
+	key := pairSplit[0]
+	value := []byte(pairSplit[1])
+	return &pair{key, value}, nil
+}
+
+// PositionalArgStringFlag implements pflag.Value that accepts a single string value
+// and stores the value in a list of values. The flag can be specified multiple
+// times to add more items the list of values.
+type PositionalArgStringFlag struct {
+	value [][]byte
+}
+
+// NewPositionalArgStringFlag returns an initialized PositionalArgStringFlag
+func NewPositionalArgStringFlag() *PositionalArgStringFlag {
+	return &PositionalArgStringFlag{}
+}
+
+// AsSlice returns a slice of values passed via the flag
+func (f *PositionalArgStringFlag) AsSlice() [][]byte {
+	return f.value
+}
+
+// String implements pflag.Value
+func (f *PositionalArgStringFlag) String() string {
+	var values []string
+	for _, value := range f.value {
+		values = append(values, string(value))
+	}
+	return fmt.Sprintf("%q", values)
+}
+
+// Set implements pflag.Value
+func (f *PositionalArgStringFlag) Set(input string) error {
+	f.value = append(f.value, []byte(input))
+	return nil
+}
+
+// Type implements pflag.Value
+func (f *PositionalArgStringFlag) Type() string {
+	return "positionalArg"
+}


### PR DESCRIPTION
So far here's I've gotten basically some similar flags to `jq`'s `--arg`, `--argjson`, `--args`, and `--jsonargs` flags. pflag doesn't support the same kind of flags so I've opted for a simpler approach for now. Later, a `jq` subcommand may be introduced that could attempt 100% command flag compatibility using something other than pflags.

In my PR, `--args` and `--argsjson` can be specified multiple times, so `--arg` and `--args`, and `--argjson` are sort of combined. For `args` the value is a string, and for `argsjson`, it's parsed as a JSON object.

`--kwargs` and `--kwargsjson` can be specified multiple times, and take a `key=value` pair. For `kwargs` value is a string, and for `kwargsjson`, it's parsed as a JSON object. Keys must be a string.

Ordering of things isn't exactly the same as jq, since flags don't really know of each other, we don't get to retain ordering of interspersed flags (eg: `--args foo --jsonargs true --args bar` is going to produce an $ARGS with `{"positional":["foo","bar",true],"named":{}}`).

Here's what a crazy command I've been using to test my process with most flags being used.

```
e:minikube,ns:default) ❯❯❯ go build . && ./faq -n -f json -o json --args '123' --jsonargs '{"json": 5}' --args 'asdf' --jsonargs '{"morejsonargs": true}' --kwargs 'foo=bar' --kwargs 'fizz=buzz' --kwargs 'dog=cool' --kwargs 'cats=mean' --args test1 --args test2 --args test3 --jsonkwargs 'testing={"testobj": {"nested": 123}}' '., $ARGS, $foo, $fizz, $testing'
null
{
  "named": {
    "cats": "mean",
    "dog": "cool",
    "fizz": "buzz",
    "foo": "bar",
    "testing": {
      "testobj": {
        "nested": 123
      }
    }
  },
  "positional": [
    "123",
    "asdf",
    "test1",
    "test2",
    "test3",
    {
      "json": 5
    },
    {
      "morejsonargs": true
    }
  ]
}
"bar"
"buzz"
{
  "testobj": {
    "nested": 123
  }
}