### PR TITLE
Support passing program from file contents using a flag --program-file/-F

### DIFF
--- a/pkg/faq/faq.go
+++ b/pkg/faq/faq.go
@@ -22,6 +22,7 @@ type Flags struct {
 	Debug        bool
 	InputFormat  string
 	OutputFormat string
+	ProgramFile  string
 	Raw          bool
 	Color        bool
 	Monochrome   bool


### PR DESCRIPTION
This enables reading a jq program from a file instead of as the first
argument. This avoids requiring a shell and using process substitution
when wanting to read the jq program as a file.