### PR TITLE
Fix error when raw output from jq produces empty string

### DIFF
--- a/pkg/faq/faq.go
+++ b/pkg/faq/faq.go
@@ -198,22 +198,25 @@ type OutputConfig struct {
 }
 
 func printValue(jqOutput string, outputWriter io.Writer, encoder formats.Encoding, conf OutputConfig) error {
-	outputFormat := formats.ToName(encoder)
-	output, err := encoder.UnmarshalJSONBytes([]byte(jqOutput))
-	if err != nil {
-		return fmt.Errorf("failed to encode jq program output as %s: %s", outputFormat, err)
-	}
-
-	if conf.Pretty {
-		output, err = encoder.PrettyPrint(output)
+	var output []byte
+	if jqOutput != "" {
+		var err error
+		output, err = encoder.UnmarshalJSONBytes([]byte(jqOutput))
 		if err != nil {
-			return fmt.Errorf("failed to encode jq program output as pretty %s: %s", outputFormat, err)
+			return fmt.Errorf("failed to encode jq program output as %s: %s", formats.ToName(encoder), err)
 		}
-	}
-	if conf.Color {
-		output, err = encoder.Color(output)
-		if err != nil {
-			return fmt.Errorf("failed to encode jq program output as color %s: %s", outputFormat, err)
+
+		if conf.Pretty {
+			output, err = encoder.PrettyPrint(output)
+			if err != nil {
+				return fmt.Errorf("failed to encode jq program output as pretty %s: %s", formats.ToName(encoder), err)
+			}
+		}
+		if conf.Color {
+			output, err = encoder.Color(output)
+			if err != nil {
+				return fmt.Errorf("failed to encode jq program output as color %s: %s", formats.ToName(encoder), err)
+			}
 		}
 	}
 

--- a/pkg/faq/faq.go
+++ b/pkg/faq/faq.go
@@ -218,6 +218,7 @@ func printValue(jqOutput string, outputWriter io.Writer, encoder formats.Encodin
 				return fmt.Errorf("failed to encode jq program output as color %s: %s", formats.ToName(encoder), err)
 			}
 		}
+		output = bytes.TrimSuffix(output, []byte("\n"))
 	}
 
 	fmt.Fprintln(outputWriter, string(output))

--- a/pkg/faq/faq_test.go
+++ b/pkg/faq/faq_test.go
@@ -16,6 +16,7 @@ func TestProcessEachFile(t *testing.T) {
 		inputFormat       string
 		outputFormat      string
 		expectedOutput    string
+		raw               bool
 	}{
 		{
 			name:              "empty file simple program",
@@ -160,6 +161,28 @@ bar: false
 			inputFormat:    "json",
 			outputFormat:   "json",
 		},
+		{
+			name:    "single file empty input raw output",
+			program: ".",
+			inputFileContents: []string{
+				``,
+			},
+			expectedOutput: "",
+			inputFormat:    "json",
+			outputFormat:   "json",
+			raw:            true,
+		},
+		{
+			name:    "single file empty string input raw output",
+			program: ".",
+			inputFileContents: []string{
+				`""`,
+			},
+			expectedOutput: "\n",
+			inputFormat:    "json",
+			outputFormat:   "json",
+			raw:            true,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -174,44 +197,7 @@ bar: false
 				})
 			}
 			var outputBuf bytes.Buffer
-			err := ProcessEachFile(testCase.inputFormat, files, testCase.program, ProgramArguments{}, &outputBuf, testCase.outputFormat, OutputConfig{}, false)
-			if err != nil {
-				t.Errorf("expected no err, got %#v", err)
-			}
-
-			output := outputBuf.String()
-			if output != testCase.expectedOutput {
-				t.Errorf("incorrect output expected=%s, got=%s", testCase.expectedOutput, output)
-			}
-		})
-	}
-}
-
-func TestExecuteProgram(t *testing.T) {
-	testCases := []struct {
-		name           string
-		program        string
-		input          *[]byte
-		inputFormat    string
-		outputFormat   string
-		programArgs    ProgramArguments
-		expectedOutput string
-	}{
-		{
-			name:           "null input simple program",
-			program:        ".",
-			input:          nil,
-			expectedOutput: "null\n",
-			inputFormat:    "json",
-			outputFormat:   "json",
-		},
-	}
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
-			encoder, _ := formats.ByName(testCase.outputFormat)
-			var outputBuf bytes.Buffer
-			err := ExecuteProgram(testCase.input, testCase.program, testCase.programArgs, &outputBuf, encoder, OutputConfig{}, false)
+			err := ProcessEachFile(testCase.inputFormat, files, testCase.program, ProgramArguments{}, &outputBuf, testCase.outputFormat, OutputConfig{}, testCase.raw)
 			if err != nil {
 				t.Errorf("expected no err, got %#v", err)
 			}
@@ -232,6 +218,7 @@ func TestSlurpAllFiles(t *testing.T) {
 		inputFormat       string
 		outputFormat      string
 		expectedOutput    string
+		raw               bool
 	}{
 
 		{
@@ -307,6 +294,28 @@ cats: dogs
 			inputFormat:  "yaml",
 			outputFormat: "json",
 		},
+		{
+			name:    "single file empty input raw output",
+			program: ".",
+			inputFileContents: []string{
+				``,
+			},
+			expectedOutput: "[]\n",
+			inputFormat:    "json",
+			outputFormat:   "json",
+			raw:            true,
+		},
+		{
+			name:    "single file empty string input raw output",
+			program: ".",
+			inputFileContents: []string{
+				`""`,
+			},
+			expectedOutput: "[\"\"]\n",
+			inputFormat:    "json",
+			outputFormat:   "json",
+			raw:            true,
+		},
 	}
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -321,7 +330,45 @@ cats: dogs
 			}
 			encoder, _ := formats.ByName(testCase.outputFormat)
 			var outputBuf bytes.Buffer
-			err := SlurpAllFiles(testCase.inputFormat, files, testCase.program, ProgramArguments{}, &outputBuf, encoder, OutputConfig{}, false)
+			err := SlurpAllFiles(testCase.inputFormat, files, testCase.program, ProgramArguments{}, &outputBuf, encoder, OutputConfig{}, testCase.raw)
+			if err != nil {
+				t.Errorf("expected no err, got %#v", err)
+			}
+
+			output := outputBuf.String()
+			if output != testCase.expectedOutput {
+				t.Errorf("incorrect output expected=%s, got=%s", testCase.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestExecuteProgram(t *testing.T) {
+	testCases := []struct {
+		name           string
+		program        string
+		input          *[]byte
+		inputFormat    string
+		outputFormat   string
+		programArgs    ProgramArguments
+		expectedOutput string
+		raw            bool
+	}{
+		{
+			name:           "null input simple program",
+			program:        ".",
+			input:          nil,
+			expectedOutput: "null\n",
+			inputFormat:    "json",
+			outputFormat:   "json",
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			encoder, _ := formats.ByName(testCase.outputFormat)
+			var outputBuf bytes.Buffer
+			err := ExecuteProgram(testCase.input, testCase.program, testCase.programArgs, &outputBuf, encoder, OutputConfig{}, testCase.raw)
 			if err != nil {
 				t.Errorf("expected no err, got %#v", err)
 			}


### PR DESCRIPTION
Fix error when raw output from jq produces empty string.

Before:

```
echo '""' | ./faq-darwin-amd64 '.'  -r -f json
Error: failed to encode jq program output as pretty javascript: unexpected end of JSON input
```

Also fixes extra newlines caused by PrettyPrint.

Before:
```
echo '""\n""' | ./faq-darwin-amd64 '.'  -M -o json -f json
""

""

```

After:
```
echo '""\n""' | ./faq-darwin-amd64 '.'  -M -o json -f json
""
""
```