### PR TITLE
Refactor encoding/decoding to default to accepting streams and writing streams

### DIFF
--- a/pkg/commands/faq.go
+++ b/pkg/commands/faq.go
@@ -168,11 +168,11 @@ func runCmdFunc(cmd *cobra.Command, args []string, flags flags) error {
 	}
 
 	if flags.ProvideNull {
-		encoder, ok := formats.ByName(flags.OutputFormat)
+		encoding, ok := formats.ByName(flags.OutputFormat)
 		if !ok {
 			return fmt.Errorf("invalid --output-format %s", flags.OutputFormat)
 		}
-		err := faq.ExecuteProgram(nil, program, programArgs, outputFile, encoder, outputConf, flags.Raw)
+		err := faq.ProcessInput(nil, program, programArgs, outputFile, encoding, outputConf, flags.Raw)
 		if err != nil {
 			return err
 		}
@@ -183,16 +183,23 @@ func runCmdFunc(cmd *cobra.Command, args []string, flags flags) error {
 		if flags.OutputFormat == "" {
 			return fmt.Errorf("must specify --output-format when using --slurp")
 		}
-		encoder, ok := formats.ByName(flags.OutputFormat)
+		encoding, ok := formats.ByName(flags.OutputFormat)
 		if !ok {
 			return fmt.Errorf("invalid --output-format %s", flags.OutputFormat)
 		}
-		err := faq.SlurpAllFiles(flags.InputFormat, files, program, programArgs, outputFile, encoder, outputConf, flags.Raw)
+		err := faq.SlurpAllFiles(flags.InputFormat, files, program, programArgs, outputFile, encoding, outputConf, flags.Raw)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := faq.ProcessEachFile(flags.InputFormat, files, program, programArgs, outputFile, flags.OutputFormat, outputConf, flags.Raw)
+		if flags.OutputFormat == "" {
+			return fmt.Errorf("must specify --output-format when using --slurp")
+		}
+		encoding, ok := formats.ByName(flags.OutputFormat)
+		if !ok {
+			return fmt.Errorf("invalid --output-format %s", flags.OutputFormat)
+		}
+		err := faq.ProcessEachFile(flags.InputFormat, files, program, programArgs, outputFile, encoding, outputConf, flags.Raw)
 		if err != nil {
 			return err
 		}

--- a/pkg/faq/faq_test.go
+++ b/pkg/faq/faq_test.go
@@ -22,6 +22,8 @@ func TestProcessEachFile(t *testing.T) {
 			name:              "empty file simple program",
 			program:           ".",
 			inputFileContents: []string{},
+			inputFormat:       "json",
+			outputFormat:      "json",
 		},
 		{
 			name:    "single file empty object simple program",
@@ -196,8 +198,14 @@ bar: false
 					data: []byte(fileContent),
 				})
 			}
+
+			encoding, ok := formats.ByName(testCase.outputFormat)
+			if !ok {
+				t.Errorf("invalid format: %s", testCase.outputFormat)
+			}
+
 			var outputBuf bytes.Buffer
-			err := ProcessEachFile(testCase.inputFormat, files, testCase.program, ProgramArguments{}, &outputBuf, testCase.outputFormat, OutputConfig{}, testCase.raw)
+			err := ProcessEachFile(testCase.inputFormat, files, testCase.program, ProgramArguments{}, &outputBuf, encoding, OutputConfig{}, testCase.raw)
 			if err != nil {
 				t.Errorf("expected no err, got %#v", err)
 			}
@@ -368,7 +376,7 @@ func TestExecuteProgram(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			encoder, _ := formats.ByName(testCase.outputFormat)
 			var outputBuf bytes.Buffer
-			err := ExecuteProgram(testCase.input, testCase.program, testCase.programArgs, &outputBuf, encoder, OutputConfig{}, testCase.raw)
+			err := ProcessInput(testCase.input, testCase.program, testCase.programArgs, &outputBuf, encoder, OutputConfig{}, testCase.raw)
 			if err != nil {
 				t.Errorf("expected no err, got %#v", err)
 			}

--- a/pkg/formats/bencode_test.go
+++ b/pkg/formats/bencode_test.go
@@ -1,6 +1,10 @@
 package formats
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func TestBencodeMarshal(t *testing.T) {
 	var table = []struct {
@@ -13,7 +17,7 @@ func TestBencodeMarshal(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run("", func(t *testing.T) {
-			outputBytes, err := bencodeEncoding{}.MarshalJSONBytes([]byte(tt.input))
+			outputBytes, err := bencodeEncoding{}.NewDecoder(strings.NewReader(tt.input)).MarshalJSONBytes()
 			if err != tt.err {
 				t.Errorf("unexpected error: %s instead of %s", err, tt.err)
 			}
@@ -30,17 +34,19 @@ func TestBencodeUnmarshal(t *testing.T) {
 		output string
 		err    error
 	}{
-		{`{"hi":"hi"}`, "d2:hi2:hie", nil},
+		{`{"hi":"hi"}`, "d2:hi2:hie\n", nil},
 	}
 
 	for _, tt := range table {
 		t.Run("", func(t *testing.T) {
-			outputBytes, err := bencodeEncoding{}.UnmarshalJSONBytes([]byte(tt.input))
+			var buf bytes.Buffer
+			err := bencodeEncoding{}.NewEncoder(&buf).UnmarshalJSONBytes([]byte(tt.input), false, false)
 			if err != tt.err {
 				t.Errorf("unexpected error: %s instead of %s", err, tt.err)
 			}
-			if string(outputBytes) != tt.output {
-				t.Errorf("unexpected output: %s instead of %s", outputBytes, tt.output)
+			output := buf.String()
+			if output != tt.output {
+				t.Errorf("unexpected output: %s instead of %s", output, tt.output)
 			}
 		})
 	}

--- a/pkg/formats/json.go
+++ b/pkg/formats/json.go
@@ -3,52 +3,27 @@ package formats
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 
 	"github.com/alecthomas/chroma/quick"
 )
 
+var (
+	_ Encoding = jsonEncoding{}
+	_ Decoder  = &jsonDecoder{}
+	_ Encoder  = &jsonEncoder{}
+)
+
 type jsonEncoding struct{}
 
-func (jsonEncoding) MarshalJSONBytes(jsonBytes []byte) ([]byte, error) {
-	// It's already JSON, silly!
-	return jsonBytes, nil
-}
-
-func (jsonEncoding) UnmarshalJSONBytes(jsonBytes []byte) ([]byte, error) {
-	// It's already JSON, silly!
-	return jsonBytes, nil
-}
-
-func (jsonEncoding) PrettyPrint(jsonBytes []byte) ([]byte, error) {
-	var i interface{}
-	err := json.Unmarshal(jsonBytes, &i)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	err = enc.Encode(i)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
-
-func (jsonEncoding) Color(jsonBytes []byte) ([]byte, error) {
-	var b bytes.Buffer
-	if err := quick.Highlight(&b, string(jsonBytes), "json", ChromaFormatter(), ChromaStyle()); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
-}
-
-func (jsonEncoding) NewDecoder(jsonBytes []byte) ToJSONDecoder {
-	decoder := json.NewDecoder(bytes.NewBuffer(jsonBytes))
+func (jsonEncoding) NewDecoder(r io.Reader) Decoder {
+	decoder := json.NewDecoder(r)
 	return &jsonDecoder{decoder}
+}
+
+func (jsonEncoding) NewEncoder(w io.Writer) Encoder {
+	return &jsonEncoder{w}
 }
 
 type jsonDecoder struct {
@@ -67,6 +42,51 @@ func (d *jsonDecoder) MarshalJSONBytes() ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+type jsonEncoder struct {
+	w io.Writer
+}
+
+func (e *jsonEncoder) UnmarshalJSONBytes(input []byte, color, pretty bool) error {
+	out, err := internalEncode(e, input, color, pretty)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(e.w, string(out))
+	return nil
+}
+
+func (jsonEncoder) unmarshalJSONBytes(jsonBytes []byte) ([]byte, error) {
+	// It's already JSON, silly!
+	return jsonBytes, nil
+}
+
+func (jsonEncoder) prettyPrint(jsonBytes []byte) ([]byte, error) {
+	var i interface{}
+	err := json.Unmarshal(jsonBytes, &i)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(i)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (jsonEncoder) color(jsonBytes []byte) ([]byte, error) {
+	var b bytes.Buffer
+	if err := quick.Highlight(&b, string(jsonBytes), "json", ChromaFormatter(), ChromaStyle()); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 func init() {

--- a/pkg/formats/xml_test.go
+++ b/pkg/formats/xml_test.go
@@ -1,6 +1,9 @@
 package formats
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 var brokenSVG = []byte(`
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -54,7 +57,7 @@ var brokenSVG = []byte(`
 `)
 
 func TestSVG(t *testing.T) {
-	_, err := xmlEncoding{}.MarshalJSONBytes(brokenSVG)
+	_, err := xmlEncoding{}.NewDecoder(bytes.NewBuffer(brokenSVG)).MarshalJSONBytes()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows (and enables for yaml/json) writing out multiple resources
in a streaming fashion, using `---` between multiple documents when
output-format is yaml, and using `\n` for other formats.

Supersedes #56

Here's what the yaml stream output looks like:
```
~/g/s/g/j/faq chance@reverse ❯❯❯ ./faq-darwin-amd64 . -o yaml <(echo '--- {}\n--- {}') <(echo '--- {}\n--- {}')
{}

---
{}

---
{}

---
{}
```

And JSON remains the same:
```
~/g/s/g/j/faq chance@reverse ❯❯❯ ./faq-darwin-amd64 . -o json <(echo '--- {}\n--- {}') <(echo '--- {}\n--- {}')
{}
{}
{}
{}
```