### PR TITLE
Fix decode infinite loop for toml, xml, bencode and bson

### DIFF
--- a/pkg/faq/faq.go
+++ b/pkg/faq/faq.go
@@ -22,7 +22,7 @@ import (
 // to a JSON value and runs ExecuteProgram against each.
 func ProcessEachFile(inputFormat string, files []File, program string, programArgs ProgramArguments, outputWriter io.Writer, outputEncoding formats.Encoding, outputConf OutputConfig, rawOutput bool) error {
 	encoder := outputEncoding.NewEncoder(outputWriter)
-	for fileNum, file := range files {
+	for _, file := range files {
 		decoderEncoding, err := determineEncoding(inputFormat, file)
 		if err != nil {
 			return err
@@ -46,7 +46,7 @@ func ProcessEachFile(inputFormat string, files []File, program string, programAr
 					return fmt.Errorf("failed to jsonify file at %s: `%s`", file.Path(), err)
 				}
 
-				logrus.Debugf("file: %s (item %d), jsonified:\n%s", file.Path(), fileNum, string(data))
+				logrus.Debugf("file: %s (item %d), jsonified:\n%s", file.Path(), itemNum, string(data))
 
 				err = processInput(&data, program, programArgs, encoder, outputConf, rawOutput)
 				if err != nil {

--- a/pkg/formats/bencode.go
+++ b/pkg/formats/bencode.go
@@ -19,7 +19,7 @@ var (
 type bencodeEncoding struct{}
 
 func (bencodeEncoding) NewDecoder(r io.Reader) Decoder {
-	return &bencodeDecoder{r}
+	return &bencodeDecoder{r, false}
 }
 
 func (e bencodeEncoding) NewEncoder(w io.Writer) Encoder {
@@ -27,14 +27,19 @@ func (e bencodeEncoding) NewEncoder(w io.Writer) Encoder {
 }
 
 type bencodeDecoder struct {
-	r io.Reader
+	r    io.Reader
+	read bool
 }
 
-func (d bencodeDecoder) MarshalJSONBytes() ([]byte, error) {
+func (d *bencodeDecoder) MarshalJSONBytes() ([]byte, error) {
+	if d.read {
+		return nil, io.EOF
+	}
 	bencodeBytes, err := ioutil.ReadAll(d.r)
 	if err != nil {
 		return nil, err
 	}
+	d.read = true
 
 	var obj interface{}
 	err = bencode.DecodeBytes(bencodeBytes, &obj)

--- a/pkg/formats/bson.go
+++ b/pkg/formats/bson.go
@@ -18,7 +18,7 @@ var (
 type bsonEncoding struct{}
 
 func (bsonEncoding) NewDecoder(r io.Reader) Decoder {
-	return &bsonDecoder{r}
+	return &bsonDecoder{r, false}
 }
 
 func (e bsonEncoding) NewEncoder(w io.Writer) Encoder {
@@ -26,14 +26,19 @@ func (e bsonEncoding) NewEncoder(w io.Writer) Encoder {
 }
 
 type bsonDecoder struct {
-	r io.Reader
+	r    io.Reader
+	read bool
 }
 
-func (d bsonDecoder) MarshalJSONBytes() ([]byte, error) {
+func (d *bsonDecoder) MarshalJSONBytes() ([]byte, error) {
+	if d.read {
+		return nil, io.EOF
+	}
 	bsonBytes, err := ioutil.ReadAll(d.r)
 	if err != nil {
 		return nil, err
 	}
+	d.read = true
 
 	var obj interface{}
 	err = bson.Unmarshal(bsonBytes, &obj)

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -9,6 +9,8 @@ import (
 
 // Decoder is able to decode a format that is isomorphic with JSON.
 type Decoder interface {
+	// MarshalJSONBytes returns a JSON value per invocation. It should return
+	// io.EOF when it reaches the end of it's stream input stream.
 	MarshalJSONBytes() ([]byte, error)
 }
 

--- a/pkg/formats/toml.go
+++ b/pkg/formats/toml.go
@@ -20,7 +20,7 @@ var (
 type tomlEncoding struct{}
 
 func (tomlEncoding) NewDecoder(r io.Reader) Decoder {
-	return &tomlDecoder{r}
+	return &tomlDecoder{r, false}
 }
 
 func (e tomlEncoding) NewEncoder(w io.Writer) Encoder {
@@ -28,14 +28,19 @@ func (e tomlEncoding) NewEncoder(w io.Writer) Encoder {
 }
 
 type tomlDecoder struct {
-	r io.Reader
+	r    io.Reader
+	read bool
 }
 
-func (d tomlDecoder) MarshalJSONBytes() ([]byte, error) {
+func (d *tomlDecoder) MarshalJSONBytes() ([]byte, error) {
+	if d.read {
+		return nil, io.EOF
+	}
 	tomlBytes, err := ioutil.ReadAll(d.r)
 	if err != nil {
 		return nil, err
 	}
+	d.read = true
 	var obj interface{}
 	err = toml.Unmarshal(tomlBytes, &obj)
 	if err != nil {

--- a/pkg/formats/xml.go
+++ b/pkg/formats/xml.go
@@ -19,7 +19,7 @@ var (
 type xmlEncoding struct{}
 
 func (xmlEncoding) NewDecoder(r io.Reader) Decoder {
-	return &xmlDecoder{r}
+	return &xmlDecoder{r, false}
 }
 
 func (e xmlEncoding) NewEncoder(w io.Writer) Encoder {
@@ -27,14 +27,19 @@ func (e xmlEncoding) NewEncoder(w io.Writer) Encoder {
 }
 
 type xmlDecoder struct {
-	r io.Reader
+	r    io.Reader
+	read bool
 }
 
-func (d xmlDecoder) MarshalJSONBytes() ([]byte, error) {
+func (d *xmlDecoder) MarshalJSONBytes() ([]byte, error) {
+	if d.read {
+		return nil, io.EOF
+	}
 	xmlBytes, err := ioutil.ReadAll(d.r)
 	if err != nil {
 		return nil, err
 	}
+	d.read = true
 
 	xmap, err := mxj.NewMapXml(xmlBytes, true)
 	if err != nil {


### PR DESCRIPTION
Currently these decoders are not using a streaming decoder so we read
everything at once using ioutil.ReadAll, which means these do not return
io.EOF as the faq code expects a decoder to return.