### PR TITLE
Wrap non-object jq results in <root> element when encoding to XML

### DIFF
--- a/pkg/formats/xml.go
+++ b/pkg/formats/xml.go
@@ -2,9 +2,11 @@ package formats
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"reflect"
 
 	"github.com/alecthomas/chroma/quick"
 	"github.com/clbanning/mxj"
@@ -53,6 +55,18 @@ type xmlEncoder struct {
 }
 
 func (e xmlEncoder) UnmarshalJSONBytes(jsonBytes []byte, color, pretty bool) error {
+	var tmp interface{}
+	err := json.Unmarshal(jsonBytes, &tmp)
+	if err != nil {
+		return err
+	}
+	if reflect.ValueOf(tmp).Kind() != reflect.Map {
+		newObj := map[string]interface{}{"root": tmp}
+		jsonBytes, err = json.Marshal(newObj)
+		if err != nil {
+			return err
+		}
+	}
 	out, err := internalEncode(e, jsonBytes, color, pretty)
 	if err != nil {
 		return err


### PR DESCRIPTION
XML requires a root element, so wrap the results in a <root> </root>
element to allow our xml encoding to succeed.

Before:
```
faq -f json -o xml '"FOO"' -n
Error: failed to encode as: json: cannot unmarshal string into Go value of type map[string]interface {}
```

After:
```
./faq-darwin-amd64 -f json -o xml '"FOO"' -n
<root>FOO</root>
```