### PR TITLE
do not pretty print when raw-output is specified

### DIFF
--- a/pkg/commands/faq.go
+++ b/pkg/commands/faq.go
@@ -147,8 +147,8 @@ func runCmdFunc(cmd *cobra.Command, args []string, flags flags) error {
 		Jsonkwargs: flags.Jsonkwargs,
 	}
 	outputConf := faq.OutputConfig{
-		Pretty: !flags.Compact && flags.Pretty,
-		Color:  color,
+		Pretty: !flags.Raw && !flags.Compact && flags.Pretty,
+		Color:  !flags.Raw && color,
 	}
 
 	if flags.ProvideNull {


### PR DESCRIPTION
@jzelinskie Here is my take!

Set outputConf related to pretty printing output to false when `--raw-output` flag is specified.

See #71.

After this change is introduced, all commands using `--raw-output` will 
lose coloring and pretty printing (which should be the expected behaviour).

Unfortunately I'm not able to build it properly on ubuntu, but the docker build works, so I guess it's ok.  
I would provide tests, but I wasn't able to understand where to put them. Any hint apreaciated!