### PR TITLE
Make the README less hostile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported formats:
 - XML
 - YAML
 
-How do you pronounce faq? "Fuck you".
+How do you pronounce faq? The same way you would insult a particularly nasty structured document: "F♥︎♥︎♥︎ You". 
 
 For example usage, read [the examples doc].
 

--- a/cmd/faq/main.go
+++ b/cmd/faq/main.go
@@ -34,8 +34,6 @@ Supported formats:
 $FAQ_FORMATTER can be set to terminal, terminal16m, json, tokens, html.
 $FAQ_STYLE can be set to any of the following themes:
 https://xyproto.github.io/splash/docs/
-
-How do you pronounce faq? "Fuck you".
 `,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Attempts to fix issue #69.

- Word the paragraph such that a warning that an insult is incoming precedes the actual insult.
- Don't actually spell out the insult.
- Make it clear that the insult is not directed at the reader, or any other person.
- Use a nice placeholder character to indicate that the insult is meant in jest, and not hostility.